### PR TITLE
Add Compat compatibility version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,7 @@ Lazy = "50d2b5c4-7a5e-59d5-8109-a42b560f39c0"
 
 [compat]
 julia = "0.7, 1"
-Compat = "1, 2, 3"
+Compat = "1, 2, 3, 4"
 Lazy = "0.13, 0.14, 0.15"
 
 [extras]


### PR DESCRIPTION
This compatibility addition appears to resolve `@assume_effects not defined` type errors like https://github.com/JuliaMath/Quadmath.jl/issues/60 that arise when executing lines or using the REPL in Atom/Juno. 